### PR TITLE
(refactor:post-location)구글맵API연동해서 위도경도로 주소변환 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ dependencies {
 	implementation 'io.lettuce:lettuce-core'  // 기본 Redis 클라이언트
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+	implementation 'com.google.code.gson:gson:2.10.1'
+
 
 	// S3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'

--- a/src/main/java/com/mokuroku/backend/BackEndApplication.java
+++ b/src/main/java/com/mokuroku/backend/BackEndApplication.java
@@ -2,7 +2,9 @@ package com.mokuroku.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class BackEndApplication {
 

--- a/src/main/java/com/mokuroku/backend/exception/ErrorCode.java
+++ b/src/main/java/com/mokuroku/backend/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
 
   // SNS
   NOT_FOUND_POST("존재하지 않는 게시글입니다.", HttpStatus.NOT_FOUND),
+  NOT_FOUND_LOCATION("존재하지 않는 위치입니다.", HttpStatus.NOT_FOUND),
   // Comments
 
   // Bookmark

--- a/src/main/java/com/mokuroku/backend/member/repository/MemberRepository.java
+++ b/src/main/java/com/mokuroku/backend/member/repository/MemberRepository.java
@@ -2,6 +2,8 @@ package com.mokuroku.backend.member.repository;
 
 import com.mokuroku.backend.member.entity.Member;
 import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,5 +13,8 @@ public interface MemberRepository extends JpaRepository<Member, String> {
   List<Member> findByStatus(char i);
 
   boolean existsByNickname(String nickname);
+
+  //토큰 아직 구현된거 아니니까 임시로 이메일 조회
+  Optional<Object> findByEmail(String email);
 }
 

--- a/src/main/java/com/mokuroku/backend/product/entity/Wishlist.java
+++ b/src/main/java/com/mokuroku/backend/product/entity/Wishlist.java
@@ -1,16 +1,8 @@
 package com.mokuroku.backend.product.entity;
 
 import com.mokuroku.backend.member.entity.Member;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +20,7 @@ import lombok.NoArgsConstructor;
 public class Wishlist {
 
   @Id
+  @Column(name = "wishlist_id")
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long wishlistId;
 

--- a/src/main/java/com/mokuroku/backend/sns/controller/PostController.java
+++ b/src/main/java/com/mokuroku/backend/sns/controller/PostController.java
@@ -20,6 +20,7 @@ public class PostController {
     // 게시글 등록 (POST)
     @PostMapping
     public ResponseEntity<ResultDTO<PostDTO>> registerPost(@RequestBody PostDTO postDTO) {
+        System.out.println("status: "+postDTO.getStatus());
         PostDTO registeredPost = postService.createPost(postDTO);
         return ResponseEntity.ok()
                 .body(new ResultDTO<>("게시글 등록에 성공했습니다.", registeredPost));

--- a/src/main/java/com/mokuroku/backend/sns/dto/PostDTO.java
+++ b/src/main/java/com/mokuroku/backend/sns/dto/PostDTO.java
@@ -1,6 +1,7 @@
 package com.mokuroku.backend.sns.dto;
 
 import com.mokuroku.backend.member.entity.Member;
+import com.mokuroku.backend.sns.entity.LocationEntity;
 import com.mokuroku.backend.sns.entity.PostEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,7 +21,8 @@ public class PostDTO {
     private Long postId;
     private String email;
     private String content;
-    private String location;
+    private Double latitude;
+    private Double longitude;
     private PostEntity.Visibility visibility;
     private LocalDateTime regDate;
     private LocalDateTime updatedDate;
@@ -29,11 +31,14 @@ public class PostDTO {
 
     // Entity를 DTO로
     public static PostDTO fromEntity(PostEntity postEntity, Member member) {
+        LocationEntity locationEntity = postEntity.getLocation();
+
         return PostDTO.builder()
                 .postId(postEntity.getPostId())
                 .email(member.getEmail())
                 .content(postEntity.getContent())
-                .location(postEntity.getLocation())
+                .latitude(locationEntity.getLatitude())
+                .longitude(locationEntity.getLongitude())
                 .visibility(postEntity.getVisibility())
                 .regDate(postEntity.getRegDate())
                 .updatedDate(postEntity.getUpdatedDate())
@@ -43,14 +48,15 @@ public class PostDTO {
     }
 
     // DTO를 Entity로
-    public PostEntity toEntity(PostDTO postDTO, Member member) {
+    public PostEntity toEntity(PostDTO postDTO, Member member,
+                               LocationEntity locationEntity) {
         return PostEntity.builder()
                 .postId(postDTO.getPostId())
                 .member(member)
                 .content(postDTO.getContent())
-                .location(postDTO.getLocation())
+                .location(locationEntity)
                 .visibility(postDTO.getVisibility())
-                .status('1') //항상 활성 상태로
+                .status(postDTO.getStatus())
                 .build();
     }
 

--- a/src/main/java/com/mokuroku/backend/sns/entity/LocationEntity.java
+++ b/src/main/java/com/mokuroku/backend/sns/entity/LocationEntity.java
@@ -1,0 +1,33 @@
+package com.mokuroku.backend.sns.entity;
+
+import com.mokuroku.backend.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "location")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LocationEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long locationId;
+
+    private Double latitude; //위도
+    private Double longitude; //경도
+    
+    private String address; // 전체 주소
+    private String city;    // 시,도
+    private String district; // 구
+    private String neighborhood; // 동
+    
+}

--- a/src/main/java/com/mokuroku/backend/sns/entity/PostEntity.java
+++ b/src/main/java/com/mokuroku/backend/sns/entity/PostEntity.java
@@ -28,13 +28,12 @@ public class PostEntity {
     @JoinColumn(name = "email", referencedColumnName = "email", nullable = false)
     private Member member;
 
-    // @Column(nullable = false, unique = true, length = 255)
-    // private String email;
-
     @Column(columnDefinition = "TEXT")
     private String content;
 
-    private String location;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "location_id")
+    private LocationEntity location;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -49,8 +48,8 @@ public class PostEntity {
 
     private LocalDateTime deleteDate;
 
-    @Column(nullable = false, length = 1)
-    private char status;
+    @Column(nullable = false)
+    private char status = '1';
 
     public enum Visibility {
         PUBLIC, PRIVATE, LIMITED
@@ -76,9 +75,9 @@ public class PostEntity {
     }
 
     // 게시물 수정 처리
-    public void update(String content, String location, Visibility visibility) {
+    public void update(String content, LocationEntity locationEntity, Visibility visibility) {
         this.content = content;
-        this.location = location;
+        this.setLocation(locationEntity);
         this.visibility = visibility;
         // updatedDate는 @LastModifiedDate로 자동 업뎃됨
     }

--- a/src/main/java/com/mokuroku/backend/sns/repository/LocationRepository.java
+++ b/src/main/java/com/mokuroku/backend/sns/repository/LocationRepository.java
@@ -1,0 +1,12 @@
+package com.mokuroku.backend.sns.repository;
+
+import com.mokuroku.backend.sns.entity.LocationEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface LocationRepository extends JpaRepository<LocationEntity, Long> {
+    Optional<LocationEntity> findByLatitudeAndLongitude(Double latitude, Double longitude);
+}

--- a/src/main/java/com/mokuroku/backend/sns/service/GooglemapService.java
+++ b/src/main/java/com/mokuroku/backend/sns/service/GooglemapService.java
@@ -1,0 +1,47 @@
+package com.mokuroku.backend.sns.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class GooglemapService {
+
+    @Value("${google.maps.api-key}")
+    private String mapApikey;
+
+    // 외부 api를 호출하기 위한 HTTP 클라이언트
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    // json 파싱
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /*
+    위도와 경도를 받아서 google Maps API를 호출하고,
+    해당 위치의 주소를 문자열로 반환
+     */
+    public JsonObject getAddressFromLatlLng(double latitude, double longitude) {
+        try {
+            String url = String.format(
+                    "https://maps.googleapis.com/maps/api/geocode/json?latlng=%f,%f&language=ko&key=%s"
+                    , latitude, longitude, mapApikey
+            );
+            // API 호출 -> JSON 문자열 응답 받기
+            ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
+
+            // Gson을 사용해 JSON 문자열을 JsonObject로 파싱
+            return JsonParser.parseString(response.getBody()).getAsJsonObject();
+
+        }  catch (Exception e) {
+            // 예외 발생 시 빈 JsonObject 반환(또는 null 반환도 가능)
+            return new JsonObject(); // 또는 null
+        }
+    }
+}

--- a/src/main/java/com/mokuroku/backend/sns/service/LocationService.java
+++ b/src/main/java/com/mokuroku/backend/sns/service/LocationService.java
@@ -1,0 +1,75 @@
+package com.mokuroku.backend.sns.service;
+
+import com.mokuroku.backend.sns.entity.LocationEntity;
+import com.mokuroku.backend.sns.repository.LocationRepository;
+import lombok.RequiredArgsConstructor;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonElement;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LocationService {
+
+    private final LocationRepository locationRepository;
+    private final GooglemapService googlemapService;
+
+    /*
+    위도,경도를 받아서 기존 Location이 있으면 재사용하고
+    없으면 주소를 변환해서 새 Location을 생성한 뒤 저장
+     */
+    public LocationEntity findOrCreate(Double latitude, Double longitude){
+        return locationRepository.findByLatitudeAndLongitude(latitude, longitude)
+                .orElseGet(() -> {
+                    // google maps api 전체 응답 json 받아옴
+                    JsonObject json = googlemapService.getAddressFromLatlLng(latitude, longitude);
+
+                    // 첫 번째 결과 추출(가장 정확한 주소 정보)
+                    JsonObject result = json.getAsJsonArray("results").get(0).getAsJsonObject();
+
+                    // 전체 주소 문자열 추출
+                    String formattedAddress = result.get("formatted_address").getAsString();
+
+                    // 주소 구성 요소 배열 추출(시/구/동 등 세부 정보포함)
+                    JsonArray components = result.getAsJsonArray("address_components");
+
+                    // 새 Location 생성
+                    LocationEntity location = new LocationEntity();
+                    location.setLatitude(latitude);
+                    location.setLongitude(longitude);
+                    location.setAddress(formattedAddress); // 전체주소 저장
+
+                    // address_components 파싱해서 city/district/neighborhood 분리해서 저장
+                    for(JsonElement comp : components){
+                        JsonObject obj = comp.getAsJsonObject();
+                        String longName = obj.get("long_name").getAsString(); // 예:서울특별시
+                        JsonArray types = obj.getAsJsonArray("types"); // 예: ["administrative_area_level_1", "political"]
+
+                        // 시(city): administrative_area_level_1
+                        if (containsType(types, "administrative_area_level_1")) {
+                            location.setCity(longName);
+                        }
+                        // 구(district): sublocality_level_1
+                        else if (containsType(types, "sublocality_level_1") || containsType(types, "sublocality")) {
+                            location.setDistrict(longName);
+                        }
+                        // 동(neighborhood): neighborhood
+                        else if (containsType(types, "neighborhood") || containsType(types, "premise")) {
+                            location.setNeighborhood(longName);
+                        }
+                    }
+
+                    return locationRepository.save(location);
+                });
+    }
+
+    private boolean containsType(JsonArray types, String targetType){
+        for (JsonElement type : types){
+            if (type.getAsString().equals(targetType)){
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/mokuroku/backend/sns/service/PostService.java
+++ b/src/main/java/com/mokuroku/backend/sns/service/PostService.java
@@ -3,6 +3,9 @@ package com.mokuroku.backend.sns.service;
 import java.util.List;
 
 import com.mokuroku.backend.sns.dto.PostDTO;
+import com.mokuroku.backend.sns.entity.LocationEntity;
+
+import javax.xml.stream.Location;
 
 public interface PostService {
 
@@ -23,4 +26,5 @@ public interface PostService {
 
     // 게시물 삭제
     void deletePost(Long postId);
+
 }


### PR DESCRIPTION
## 🛠️ PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [✔️ ] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

<br/>

## 💾 반영 브랜치

ex) refactor/post-location -> main

<br/>

## 👨‍🔧 변경사항

<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->

- **AS-IS**
post기능에서 location 태깅이 안되어 있어서 location을 googleAPI로 연동해서 리팩토링 했습니다.
위도,경도를 받아 한글 주소로 변환해주고 전체주소와 시,구,동 나누어 DB에 저장해주는 기능으로 구현했습니다.
- **TO-BE**
- 일단 RestTemplate으로 했는데 다른 라이브러리로 리팩토링 할 예정
  <br />

## 🎨 이미지 첨부
<img width="863" height="115" alt="image" src="https://github.com/user-attachments/assets/1d5d861e-878e-4691-a25a-5d704b4e933b" />

## 👨‍💻 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->

- [ ] 테스트 코드
- [✔️ ] API 테스트

<br/>
